### PR TITLE
Fix ng output path in dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -23,7 +23,7 @@ USER root
 RUN rm -rf /usr/share/nginx/html/*
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY nginx-basehref.sh /docker-entrypoint.d/90-basehref.sh
-COPY --from=builder /ng-app/dist /usr/share/nginx/html
+COPY --from=builder /ng-app/dist/cite-ui/browser /usr/share/nginx/html
 RUN chown -R nginx:nginx /usr/share/nginx/html && \
   chmod +x /docker-entrypoint.d/90-basehref.sh
 USER nginx

--- a/dockerfile
+++ b/dockerfile
@@ -23,7 +23,7 @@ USER root
 RUN rm -rf /usr/share/nginx/html/*
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY nginx-basehref.sh /docker-entrypoint.d/90-basehref.sh
-COPY --from=builder /ng-app/dist/cite-ui/browser /usr/share/nginx/html
+COPY --from=builder /ng-app/dist/browser /usr/share/nginx/html
 RUN chown -R nginx:nginx /usr/share/nginx/html && \
   chmod +x /docker-entrypoint.d/90-basehref.sh
 USER nginx


### PR DESCRIPTION
This PR updates the angular build path in the dockerfile to resolve a bug related to hosting the app using path-based routing.

Angular 17 changed the build output path to include a /browser/ subdir with a [new application builder](https://angular.dev/tools/cli/build-system-migration).  As part of this update, the 90-basehref.sh script was failing when the app was hosted in a path.  