### PR TITLE
Load users per evaluation to avoid permission errors

### DIFF
--- a/src/app/components/home-app/home-app.component.ts
+++ b/src/app/components/home-app/home-app.component.ts
@@ -332,11 +332,10 @@ export class HomeAppComponent implements OnDestroy, OnInit {
           }
         });
       this.setDataSources();
-      // load users for evaluation creators
-      const creatorIds = new Set(evaluations.map(e => e.createdBy).filter(id => id && id !== '00000000-0000-0000-0000-000000000000'));
-      creatorIds.forEach(userId => {
-        if (!this.userQuery.getEntity(userId)) {
-          this.userDataService.loadById(userId).pipe(take(1)).subscribe();
+      // Load users for each evaluation (for displaying creator names)
+      evaluations.forEach(evaluation => {
+        if (evaluation.id) {
+          this.userDataService.loadByEvaluation(evaluation.id).pipe(take(1)).subscribe();
         }
       });
     });


### PR DESCRIPTION
Changed user loading strategy to use GET /evaluations/{id}/users instead of GET /users/{id} for individual creators. This avoids 403 errors for users who don't have ViewUsers system permission but can still access evaluations they're members of. Users are now loaded per evaluation, which only requires evaluation access rather than system-level user viewing permissions.