### PR TITLE
Fix role dropdown styling, admin access, and improve action/duty UI

### DIFF
--- a/src/app/components/admin/admin-action-edit-dialog/admin-action-edit-dialog.component.html
+++ b/src/app/components/admin/admin-action-edit-dialog/admin-action-edit-dialog.component.html
@@ -5,7 +5,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
 -->
 
 <div mat-dialog-title>
-  &nbsp;
+  {{ data?.action?.id ? 'Edit Action' : 'Add Action' }}
   <button
     mat-icon-button
     (click)="handleEditComplete(false)"
@@ -18,7 +18,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
 </div>
 @if (data && data.action) {
   <div mat-dialog-content>
-    <div>
+    <div class="add-margin">
       <div>
         <mat-form-field class="description-field full-width">
           <mat-label>Action Description</mat-label>

--- a/src/app/components/admin/admin-container/admin-container.component.ts
+++ b/src/app/components/admin/admin-container/admin-container.component.ts
@@ -119,8 +119,12 @@ export class AdminContainerComponent implements OnDestroy, OnInit {
         this.displayedSection = section;
       });
     this.originalEvaluationId = this.evaluationQuery.getActiveId();
-    // load Evaluations
-    this.evaluationDataService.load();
+    // load Evaluations based on user permissions
+    if (this.permissionDataService.hasPermission(SystemPermission.ViewEvaluations)) {
+      this.evaluationDataService.load();
+    } else {
+      this.evaluationDataService.loadMine();
+    }
     // load and subscribe to TeamTypes
     this.teamTypeDataService.load();
     // Set the display settings from config file
@@ -134,17 +138,20 @@ export class AdminContainerComponent implements OnDestroy, OnInit {
 
   ngOnInit() {
     this.userList = this.userQuery.selectAll();
-    this.userDataService.load().pipe(take(1)).subscribe();
     this.permissionDataService.load().subscribe((x) => {
       this.permissions = this.permissionDataService.permissions;
-      this.canViewScoringModels = this.canViewScoringModels || this.permissionDataService.hasPermission(SystemPermission.ViewScoringModels);
+      this.canViewScoringModels = this.permissionDataService.hasPermission(SystemPermission.ViewScoringModels);
       this.canCreateScoringModels = this.permissionDataService.hasPermission(SystemPermission.CreateScoringModels);
-      this.canViewEvaluations = this.canViewEvaluations || this.permissionDataService.hasPermission(SystemPermission.ViewEvaluations);
+      this.canViewEvaluations = this.permissionDataService.hasPermission(SystemPermission.ViewEvaluations);
       this.canCreateEvaluations = this.permissionDataService.hasPermission(SystemPermission.CreateEvaluations);
       this.canViewGroups = this.permissionDataService.hasPermission(SystemPermission.ViewGroups);
       this.canViewRoles = this.permissionDataService.hasPermission(SystemPermission.ViewRoles);
       this.canViewTeamTypes = this.permissionDataService.hasPermission(SystemPermission.ViewTeamTypes);
       this.canViewUsers = this.permissionDataService.hasPermission(SystemPermission.ViewUsers);
+      // Only load users if user has permission
+      if (this.canViewUsers) {
+        this.userDataService.load().pipe(take(1)).subscribe();
+      }
     });
     this.permissionDataService.loadScoringModelPermissions().subscribe();
     this.permissionDataService.loadEvaluationPermissions().subscribe();

--- a/src/app/components/admin/admin-duty-edit-dialog/admin-duty-edit-dialog.component.html
+++ b/src/app/components/admin/admin-duty-edit-dialog/admin-duty-edit-dialog.component.html
@@ -5,7 +5,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
 -->
 
 <div mat-dialog-title>
-  &nbsp;
+  {{ data?.duty?.id ? 'Edit Duty' : 'Add Duty' }}
   <button
     mat-icon-button
     (click)="handleEditComplete(false)"

--- a/src/app/components/admin/admin-evaluation-memberships/admin-evaluation-member-list/admin-evaluation-member-list.component.scss
+++ b/src/app/components/admin/admin-evaluation-memberships/admin-evaluation-member-list/admin-evaluation-member-list.component.scss
@@ -36,7 +36,7 @@ mat-paginator {
 
 mat-select {
   font-size: 14px;
-  width: 140px;
+  width: 150px;
 }
 
 ::ng-deep .mat-mdc-option {

--- a/src/app/components/admin/admin-evaluation-memberships/admin-evaluation-member-list/admin-evaluation-member-list.component.scss
+++ b/src/app/components/admin/admin-evaluation-memberships/admin-evaluation-member-list/admin-evaluation-member-list.component.scss
@@ -33,3 +33,16 @@ mat-paginator {
 .w-50 {
   width: 50%;
 }
+
+mat-select {
+  font-size: 14px;
+  width: 140px;
+}
+
+::ng-deep .mat-mdc-option {
+  font-size: 14px;
+}
+
+::ng-deep .mdc-list-item__primary-text {
+  white-space: nowrap;
+}

--- a/src/app/components/admin/admin-evaluations/admin-evaluations.component.scss
+++ b/src/app/components/admin/admin-evaluations/admin-evaluations.component.scss
@@ -64,7 +64,7 @@ tr.detail-row {
 }
 
 .mat-column-currentMoveNumber {
-  min-width: 140px;
+  min-width: 150px;
   text-align: center;
 }
 

--- a/src/app/components/admin/admin-groups/admin-groups.component.scss
+++ b/src/app/components/admin/admin-groups/admin-groups.component.scss
@@ -49,8 +49,8 @@ table {
 }
 
 .mat-column-actions {
-  width: 140px;
-  max-width: 140px;
+  width: 150px;
+  max-width: 150px;
   white-space: nowrap;
 }
 

--- a/src/app/components/admin/admin-scoring-model-memberships/admin-scoring-model-member-list/admin-scoring-model-member-list.component.scss
+++ b/src/app/components/admin/admin-scoring-model-memberships/admin-scoring-model-member-list/admin-scoring-model-member-list.component.scss
@@ -36,7 +36,7 @@ mat-paginator {
 
 mat-select {
   font-size: 14px;
-  width: 140px;
+  width: 150px;
 }
 
 ::ng-deep .mat-mdc-option {

--- a/src/app/components/admin/admin-scoring-model-memberships/admin-scoring-model-member-list/admin-scoring-model-member-list.component.scss
+++ b/src/app/components/admin/admin-scoring-model-memberships/admin-scoring-model-member-list/admin-scoring-model-member-list.component.scss
@@ -33,3 +33,16 @@ mat-paginator {
 .w-50 {
   width: 50%;
 }
+
+mat-select {
+  font-size: 14px;
+  width: 140px;
+}
+
+::ng-deep .mat-mdc-option {
+  font-size: 14px;
+}
+
+::ng-deep .mdc-list-item__primary-text {
+  white-space: nowrap;
+}

--- a/src/app/components/admin/admin-team-memberships/admin-team-member-list/admin-team-member-list.component.scss
+++ b/src/app/components/admin/admin-team-memberships/admin-team-member-list/admin-team-member-list.component.scss
@@ -36,7 +36,7 @@ mat-paginator {
 
 ::ng-deep .mat-column-role mat-select {
   font-size: 14px;
-  width: 140px;
+  width: 150px;
 }
 
 ::ng-deep .mat-mdc-option {

--- a/src/app/components/admin/admin-team-memberships/admin-team-member-list/admin-team-member-list.component.scss
+++ b/src/app/components/admin/admin-team-memberships/admin-team-member-list/admin-team-member-list.component.scss
@@ -33,3 +33,16 @@ mat-paginator {
 .w-50 {
   width: 50%;
 }
+
+::ng-deep .mat-column-role mat-select {
+  font-size: 14px;
+  width: 140px;
+}
+
+::ng-deep .mat-mdc-option {
+  font-size: 14px;
+}
+
+::ng-deep .mdc-list-item__primary-text {
+  white-space: nowrap;
+}

--- a/src/app/components/admin/admin-team-memberships/admin-team-memberships/admin-team-memberships.component.scss
+++ b/src/app/components/admin/admin-team-memberships/admin-team-memberships/admin-team-memberships.component.scss
@@ -5,7 +5,7 @@ Copyright 2025 Carnegie Mellon University. All Rights Reserved.
 
 ::ng-deep mat-select {
   font-size: 14px;
-  width: 140px;
+  width: 150px;
 }
 
 ::ng-deep .mat-mdc-option {

--- a/src/app/components/admin/admin-team-memberships/admin-team-memberships/admin-team-memberships.component.scss
+++ b/src/app/components/admin/admin-team-memberships/admin-team-memberships/admin-team-memberships.component.scss
@@ -2,3 +2,16 @@
 Copyright 2025 Carnegie Mellon University. All Rights Reserved.
  Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 */
+
+::ng-deep mat-select {
+  font-size: 14px;
+  width: 140px;
+}
+
+::ng-deep .mat-mdc-option {
+  font-size: 14px;
+}
+
+::ng-deep .mdc-list-item__primary-text {
+  white-space: nowrap;
+}

--- a/src/app/components/admin/admin-users/admin-user-list/admin-user-list.component.scss
+++ b/src/app/components/admin/admin-users/admin-user-list/admin-user-list.component.scss
@@ -68,3 +68,16 @@ table {
   display: flex;
   align-items: center;
 }
+
+mat-select {
+  font-size: 14px;
+  width: 140px;
+}
+
+::ng-deep .mat-mdc-option {
+  font-size: 14px;
+}
+
+::ng-deep .mdc-list-item__primary-text {
+  white-space: nowrap;
+}

--- a/src/app/components/admin/admin-users/admin-user-list/admin-user-list.component.scss
+++ b/src/app/components/admin/admin-users/admin-user-list/admin-user-list.component.scss
@@ -71,7 +71,7 @@ table {
 
 mat-select {
   font-size: 14px;
-  width: 140px;
+  width: 150px;
 }
 
 ::ng-deep .mat-mdc-option {

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -21,17 +21,36 @@ project root for license information or contact permission@sei.cmu.edu for full 
   </div>
   }
   <!-- Actions section -->
+  @if (!showActions) {
   <div class="row-container">
     <div class="section-container four-cell">
       <div class="row-container">
+        <div class="two-cell center-self">
+          <button mat-icon-button (click)="showActions = true" title="Expand the actions">
+            <mat-icon class="mdi-24px self-center" fontIcon="mdi-menu-down"></mat-icon>
+          </button>
+          <b title="Participant Actions during an Exercise">Actions:</b>
+        </div>
+        <div class="checkboxes-cell">&nbsp;</div>
+      </div>
+    </div>
+  </div>
+  }
+  @if (showActions) {
+  <div class="row-container">
+    <div class="section-container mat-elevation-z8 four-cell">
+      <div class="row-container">
         <div class="five-cell center-self">
+          <button mat-icon-button (click)="showActions = false" title="Collapse the actions">
+            <mat-icon class="mdi-24px self-center" fontIcon="mdi-menu-up"></mat-icon>
+          </button>
           <b title="Participant Actions during an Exercise">Actions:</b>
         </div>
         @if (myTeamId === activeTeamId) {
         <div class="right-cell">
           @if (!isActionEditMode) {
           <button mat-icon-button (click)="isActionEditMode = true" title="Edit Actions"
-            [disabled]="noChanges || !canManageTeam">
+            [disabled]="noChanges || !canSubmitTeamScore">
             <mat-icon class="mdi-24px" fontIcon="mdi-square-edit-outline">
             </mat-icon>
           </button>
@@ -76,6 +95,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
       }
     </div>
   </div>
+  }
   <!-- Duties Section -->
   @if (!showDuties) {
   <div class="row-container">
@@ -105,7 +125,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
         <div class="right-cell">
           @if (!isDutyEditMode) {
           <button mat-icon-button (click)="isDutyEditMode = true" title="Edit Duties"
-            [disabled]="noChanges || !canManageTeam">
+            [disabled]="noChanges || !canSubmitTeamScore">
             <mat-icon class="mdi-24px" fontIcon="mdi-square-edit-outline">
             </mat-icon>
           </button>
@@ -140,7 +160,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
           <label>{{ duty.name }}</label>
         </div>
         <div class="five-cell center-self">
-          @if (!isDutyEditMode && canManageTeam) {
+          @if (!isDutyEditMode && canContributeToTeamScore) {
           <mat-select placeholder="Assign Users" [value]="duty.users" multiple (opened)="openDutyUsers(duty)"
             (selectionChange)="updateDutyUsers(duty.id, $event)" (closed)="closeDutyUsers(duty.id)"
             [disabled]="noChanges || myTeamId !== activeTeamId" title="Select a Team Member">
@@ -150,7 +170,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
             }
           </mat-select>
           }
-          @if (isDutyEditMode || !canManageTeam) {
+          @if (isDutyEditMode || !canContributeToTeamScore) {
           <span>{{ getUserNames(duty.users) }}</span>
           }
         </div>

--- a/src/app/components/dashboard/dashboard.component.scss
+++ b/src/app/components/dashboard/dashboard.component.scss
@@ -24,6 +24,11 @@
   flex-wrap: wrap;
   width: 100%;
   min-height: 40px;
+
+  .center-self {
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
 }
 
 .first-row {
@@ -67,7 +72,7 @@
 }
 
 .mat-mdc-checkbox {
-  padding: 10px;
+  padding: 2px 10px 2px 2px;
 }
 
 .duty-container {
@@ -143,6 +148,7 @@
   flex-direction: row;
   flex: 5;
   align-self: center;
+  justify-content: flex-end;
 }
 
 .five-cell {
@@ -167,4 +173,50 @@
 
 .center-self {
   align-self: center;
+}
+
+.checkboxes-cell mat-form-field {
+  width: 100% !important;
+  max-width: none !important;
+}
+
+.checkboxes-cell mat-select {
+  font-size: 14px;
+  width: 100%;
+  text-align: right;
+}
+
+::ng-deep .mat-mdc-option {
+  font-size: 14px;
+  text-align: right;
+}
+
+::ng-deep .mdc-list-item__primary-text {
+  white-space: nowrap;
+  text-align: right;
+  width: 100%;
+}
+
+::ng-deep .checkboxes-cell .mat-mdc-select-value-text {
+  text-align: right;
+}
+
+::ng-deep .checkboxes-cell .mat-mdc-select-trigger {
+  text-align: right;
+}
+
+.section-container .row-container {
+  min-height: 26px;
+  margin-bottom: 2px;
+
+  button[mat-icon-button] {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+  }
+}
+
+.section-container > .row-container:first-of-type {
+  min-height: 36px;
+  margin-bottom: 2px;
 }

--- a/src/app/components/dashboard/dashboard.component.scss
+++ b/src/app/components/dashboard/dashboard.component.scss
@@ -176,13 +176,13 @@
 }
 
 .checkboxes-cell mat-form-field {
-  width: 100% !important;
-  max-width: none !important;
+  width: 150px !important;
+  max-width: 150px !important;
 }
 
 .checkboxes-cell mat-select {
   font-size: 14px;
-  width: 100%;
+  width: 150px;
   text-align: right;
 }
 

--- a/src/app/components/dashboard/dashboard.component.scss
+++ b/src/app/components/dashboard/dashboard.component.scss
@@ -168,3 +168,16 @@
 .center-self {
   align-self: center;
 }
+
+.checkboxes-cell mat-select {
+  font-size: 14px;
+  width: 140px;
+}
+
+::ng-deep .mat-mdc-option {
+  font-size: 14px;
+}
+
+::ng-deep .mdc-list-item__primary-text {
+  white-space: nowrap;
+}

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -91,6 +91,7 @@ export class DashboardComponent implements OnDestroy {
   loggedInUserId = '';
   showPermissions = false;
   showDuties = false;
+  showActions = true;
   canManageTeam = false;
   canSubmitTeamScore = false;
   canContributeToTeamScore = false;
@@ -370,6 +371,9 @@ export class DashboardComponent implements OnDestroy {
       width: 'auto',
       data: {
         action: action,
+        teamList: [],
+        moveList: [],
+        allMovesValue: -999
       },
     });
     dialogRef.componentInstance.editComplete.subscribe((result) => {
@@ -453,7 +457,7 @@ export class DashboardComponent implements OnDestroy {
       width: 'auto',
       data: {
         duty: duty,
-        canEdit: this.canManageTeam
+        canEdit: this.canSubmitTeamScore
       },
     });
     dialogRef.componentInstance.editComplete.subscribe((result) => {

--- a/src/app/components/home-app/home-app.component.ts
+++ b/src/app/components/home-app/home-app.component.ts
@@ -174,7 +174,7 @@ export class HomeAppComponent implements OnDestroy, OnInit {
       .subscribe(
         (x) => {
           this.permissions = this.permissionDataService.permissions;
-          this.canViewAdministration = this.permissions.some((y) => y.startsWith('View'));
+          this.canViewAdministration = this.permissionDataService.canViewAdministration();
         }
       );
     // load evaluation permissions

--- a/src/app/data/permission/permission-data.service.ts
+++ b/src/app/data/permission/permission-data.service.ts
@@ -61,7 +61,27 @@ export class PermissionDataService {
   }
 
   canViewAdministration() {
-    return this._permissions.some((y) => y.startsWith('View'));
+    const adminPermissions: SystemPermission[] = [
+      SystemPermission.ViewEvaluations,
+      SystemPermission.EditEvaluations,
+      SystemPermission.ManageEvaluations,
+      SystemPermission.CreateEvaluations,
+      SystemPermission.ExecuteEvaluations,
+      SystemPermission.ViewScoringModels,
+      SystemPermission.EditScoringModels,
+      SystemPermission.ManageScoringModels,
+      SystemPermission.CreateScoringModels,
+      SystemPermission.ViewUsers,
+      SystemPermission.ManageUsers,
+      SystemPermission.ViewRoles,
+      SystemPermission.ManageRoles,
+      SystemPermission.ViewGroups,
+      SystemPermission.ManageGroups,
+      SystemPermission.ViewTeamTypes,
+      SystemPermission.ManageTeamTypes
+    ];
+
+    return this._permissions.some((perm) => adminPermissions.includes(perm));
   }
 
   loadEvaluationPermissions(): Observable<EvaluationPermissionClaim[]> {

--- a/src/app/data/team/team-data.service.ts
+++ b/src/app/data/team/team-data.service.ts
@@ -186,6 +186,8 @@ export class TeamDataService {
           this.teamStore.set(teams);
         },
         (error) => {
+          // Handle 403 silently - user may not have permission to view teams
+          this.teamStore.setLoading(false);
           this.teamStore.set([]);
         }
       );


### PR DESCRIPTION
  ## Summary
  - Fix role dropdown font size and text wrapping across all admin components
  - Fix admin section access for content developers
  - Improve action and duty dialog UI with collapsible sections
  - Update permission checks to align with team role hierarchy

  ## Changes

  **Role Dropdown Styling:**
  - Set font size to 14px and width to 140px to prevent text wrapping
  - Apply consistent styling across dashboard, admin evaluations, teams, and scoring models

  **Admin Section Access:**
  - Fix permission checks to properly validate content developer access
  - Update permission data service to handle evaluation-level permissions

  **Action/Duty Dialog Improvements:**
  - Add dynamic titles ("Edit Action" vs "Add Action", "Edit Duty" vs "Add Duty")
  - Fix action dialog Material form field rendering
  - Add collapsible/expandable functionality to Actions section (matching Duties and Roles)
  - Reduce spacing between action and duty items for compact display
  - Align role dropdown content to the right
  - Reduce checkbox padding and icon button sizes

  **Permission Check Updates:**
  - Change action edit button from `canManageTeam` to `canSubmitTeamScore`
  - Change duty edit button from `canManageTeam` to `canSubmitTeamScore`
  - Change duty assignment from `canManageTeam` to `canContributeToTeamScore`
  - Update duty dialog `canEdit` from `canManageTeam` to `canSubmitTeamScore`

  ## Test Plan
  - [ ] Verify role dropdowns display "Contributor" without wrapping
  - [ ] Verify content developers can access appropriate admin sections
  - [ ] Verify action dialog renders with proper Material styling
  - [ ] Verify Actions section can be collapsed/expanded
  - [ ] Verify Contributors can check actions and assign duties
  - [ ] Verify Submitters can create actions and duties
  - [ ] Verify Owners can edit and delete actions/duties