### PR TITLE
Fix scoring model tooltip username display

### DIFF
--- a/src/app/components/aggregate/aggregate.component.ts
+++ b/src/app/components/aggregate/aggregate.component.ts
@@ -9,6 +9,8 @@ import { takeUntil } from 'rxjs/operators';
 import { EvaluationQuery } from 'src/app/data/evaluation/evaluation.query';
 import { ScoringModelQuery } from 'src/app/data/scoring-model/scoring-model.query';
 import { TeamQuery } from 'src/app/data/team/team.query';
+import { UserDataService } from 'src/app/data/user/user-data.service';
+import { UserQuery } from 'src/app/data/user/user.query';
 import { CurrentUserQuery } from 'src/app/data/user/user.query';
 import { ItemStatus,
   Evaluation,
@@ -58,6 +60,8 @@ export class AggregateComponent implements OnInit, OnDestroy {
 
   constructor(
     private submissionService: SubmissionService,
+    private userDataService: UserDataService,
+    private userQuery: UserQuery,
     private currentUserQuery: CurrentUserQuery,
     private teamService: TeamService,
     private teamQuery: TeamQuery,
@@ -76,6 +80,13 @@ export class AggregateComponent implements OnInit, OnDestroy {
           this.userId = this.loggedInUserId;
         }
       });
+    this.userDataService.setCurrentUser();
+    // observe the evaluation users
+    this.userQuery.selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(users => {
+        this.userList = users;
+      });
   }
 
   ngOnInit() {
@@ -88,7 +99,6 @@ export class AggregateComponent implements OnInit, OnDestroy {
     combineLatest([this.teamList$, this.submissionList$])
       .pipe(takeUntil(this.unsubscribe$)).subscribe(([teams, submissions]) => {
         this.teamList = teams.length > 0 ? teams.sort((a, b) => a.shortName < b.shortName ? -1 : 1) : [];
-        this.userList = teams.length > 0 ? this.getUserListFromTeams(teams) : [];
         this.getPopulatedSubmissions(submissions);
       });
   }

--- a/src/app/components/report/report.component.ts
+++ b/src/app/components/report/report.component.ts
@@ -11,6 +11,8 @@ import { ScoringModelQuery } from 'src/app/data/scoring-model/scoring-model.quer
 import { SubmissionDataService } from 'src/app/data/submission/submission-data.service';
 import { SubmissionQuery } from 'src/app/data/submission/submission.query';
 import { TeamQuery } from 'src/app/data/team/team.query';
+import { UserDataService } from 'src/app/data/user/user-data.service';
+import { UserQuery } from 'src/app/data/user/user.query';
 import { CurrentUserQuery } from 'src/app/data/user/user.query';
 import {
   ItemStatus,
@@ -40,6 +42,7 @@ export class ReportComponent implements OnDestroy {
   loggedInUserName = '';
   selectedTeam: Team = {};
   teamUsers: User[];
+  evaluationUsers: User[] = [];
   currentMoveNumber = -1;
   displayedMoveNumber = -1;
   displayedSubmissionList: PopulatedSubmission[] = [];
@@ -66,6 +69,8 @@ export class ReportComponent implements OnDestroy {
     private submissionDataService: SubmissionDataService,
     private submissionQuery: SubmissionQuery,
     private evaluationQuery: EvaluationQuery,
+    private userDataService: UserDataService,
+    private userQuery: UserQuery,
     private currentUserQuery: CurrentUserQuery,
     private teamQuery: TeamQuery,
     private dialogService: DialogService,
@@ -104,6 +109,13 @@ export class ReportComponent implements OnDestroy {
           this.loggedInUserId = user.id;
           this.loggedInUserName = user.name;
         }
+      });
+    this.userDataService.setCurrentUser();
+    // observe the evaluation users
+    this.userQuery.selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(users => {
+        this.evaluationUsers = users;
       });
     // observe the submission list
     this.submissionQuery
@@ -252,7 +264,7 @@ export class ReportComponent implements OnDestroy {
   }
 
   getUserName(id) {
-    const theUser = this.teamUsers?.find((tu) => tu.id === id);
+    const theUser = this.evaluationUsers?.find((u) => u.id === id);
     return theUser ? theUser.name : '';
   }
 

--- a/src/app/components/scoresheet/scoresheet.component.html
+++ b/src/app/components/scoresheet/scoresheet.component.html
@@ -197,7 +197,7 @@ project root for license information or contact permission@sei.cmu.edu for full 
                   scoringOption.id
                   )
                   ; track
-                  comment) {
+                  comment.id) {
                   <div>
                     {{ comment.comment }}
                     @if (displaying === 'team') {

--- a/src/app/components/scoresheet/scoresheet.component.ts
+++ b/src/app/components/scoresheet/scoresheet.component.ts
@@ -20,6 +20,7 @@ import { SubmissionQuery } from 'src/app/data/submission/submission.query';
 import { TeamQuery } from 'src/app/data/team/team.query';
 import { TeamMembershipDataService } from 'src/app/data/team/team-membership-data.service';
 import { UserDataService } from 'src/app/data/user/user-data.service';
+import { UserQuery } from 'src/app/data/user/user.query';
 import { CurrentUserQuery } from 'src/app/data/user/user.query';
 import {
   ItemStatus,
@@ -53,6 +54,7 @@ export class ScoresheetComponent implements OnDestroy {
   userId = '';
   activeTeamId = '';
   teamMemberships: User[];
+  evaluationUsers: User[] = [];
   currentMoveNumber: number;
   displayedMoveNumber: number;
   selectedEvaluation: Evaluation = {};
@@ -86,6 +88,7 @@ export class ScoresheetComponent implements OnDestroy {
     private submissionQuery: SubmissionQuery,
     private evaluationQuery: EvaluationQuery,
     private userDataService: UserDataService,
+    private userQuery: UserQuery,
     private currentUserQuery: CurrentUserQuery,
     private teamQuery: TeamQuery,
     private teamMembershipDataService: TeamMembershipDataService,
@@ -165,6 +168,12 @@ export class ScoresheetComponent implements OnDestroy {
         this.loggedInUserId = cu.id;
       });
     this.userDataService.setCurrentUser();
+    // observe the evaluation users
+    this.userQuery.selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(users => {
+        this.evaluationUsers = users;
+      });
     // observe the submission list
     this.submissionQuery
       .selectAll()
@@ -435,7 +444,7 @@ export class ScoresheetComponent implements OnDestroy {
   }
 
   getUserName(id) {
-    const theUser = this.teamMemberships?.find((tu) => tu.id === id);
+    const theUser = this.evaluationUsers?.find((u) => u.id === id);
     return theUser ? theUser.name : '';
   }
 


### PR DESCRIPTION
   The tooltip for scoring options in team view was showing 'Selected by' or 'Unselected by' without displaying the username. This occurred because the permissions refactor (October 2025) changed Team.Users to Team.Memberships, but the
    getUserName() lookup was not updated to account for the new data structure.

   TeamMembership objects contain userId and roleId, but not the full User object with name property. The membership ID (TeamMembership.id) is different from the user ID (TeamMembership.userId).

   This fix updates scoresheet, report, and aggregate components to load evaluation users separately via UserQuery and lookup usernames from the evaluationUsers array instead of trying to extract them from team memberships.

   Also fixes Angular tracking expression warning in scoresheet.component.html by using comment.id instead of comment object identity.