### PR TITLE
Improve comment dialog theming and layout

### DIFF
--- a/src/app/components/scoresheet/scoresheet.component.html
+++ b/src/app/components/scoresheet/scoresheet.component.html
@@ -272,10 +272,13 @@ project root for license information or contact permission@sei.cmu.edu for full 
 </div>
 
 <ng-template #addCommenttemplate>
-  <h1>Add a comment ...</h1>
-  <mat-form-field class="full-width">
-    <textarea matInput placeholder="{{ commentOptionDescription }}" [(ngModel)]="currentComment"></textarea>
-  </mat-form-field>
+  <div mat-dialog-title>Add a comment ...</div>
+  <div mat-dialog-content>
+    <mat-form-field class="full-width">
+      <mat-label>{{ commentOptionDescription }}</mat-label>
+      <textarea matInput placeholder="" [(ngModel)]="currentComment"></textarea>
+    </mat-form-field>
+  </div>
 
   <mat-dialog-actions>
     <button mat-button mat-dialog-close>Cancel</button>

--- a/src/app/components/scoresheet/scoresheet.component.ts
+++ b/src/app/components/scoresheet/scoresheet.component.ts
@@ -299,7 +299,7 @@ export class ScoresheetComponent implements OnDestroy {
     this.commentOptionDescription = scoringOption.description;
     const dialogRef = this.matDialog.open(templateRef, {
       maxWidth: '90vw',
-      width: 'auto',
+      width: '600px',
     });
     dialogRef.disableClose = true;
     dialogRef.afterClosed().subscribe((result) => {
@@ -324,7 +324,7 @@ export class ScoresheetComponent implements OnDestroy {
     this.commentOptionDescription = scoringOption.description;
     const dialogRef = this.matDialog.open(templateRef, {
       maxWidth: '90vw',
-      width: 'auto',
+      width: '600px',
     });
     dialogRef.disableClose = true;
     dialogRef.afterClosed().subscribe((result) => {


### PR DESCRIPTION
- Add proper mat-dialog-title and mat-dialog-content wrappers for Material Design theming
- Convert scoring option description from placeholder to mat-label
- Set blank placeholder for textarea input
- Increase dialog width from 'auto' to 600px for better readability