### PR TITLE
Fix admin evaluation page scoring model filter and data loading

### DIFF
--- a/src/app/components/admin/admin-container/admin-container.component.ts
+++ b/src/app/components/admin/admin-container/admin-container.component.ts
@@ -119,12 +119,6 @@ export class AdminContainerComponent implements OnDestroy, OnInit {
         this.displayedSection = section;
       });
     this.originalEvaluationId = this.evaluationQuery.getActiveId();
-    // load Evaluations based on user permissions
-    if (this.permissionDataService.hasPermission(SystemPermission.ViewEvaluations)) {
-      this.evaluationDataService.load();
-    } else {
-      this.evaluationDataService.loadMine();
-    }
     // load and subscribe to TeamTypes
     this.teamTypeDataService.load();
     // Set the display settings from config file
@@ -148,6 +142,12 @@ export class AdminContainerComponent implements OnDestroy, OnInit {
       this.canViewRoles = this.permissionDataService.hasPermission(SystemPermission.ViewRoles);
       this.canViewTeamTypes = this.permissionDataService.hasPermission(SystemPermission.ViewTeamTypes);
       this.canViewUsers = this.permissionDataService.hasPermission(SystemPermission.ViewUsers);
+      // Load evaluations based on user permissions (must be inside load callback so permissions are available)
+      if (this.canViewEvaluations) {
+        this.evaluationDataService.load();
+      } else {
+        this.evaluationDataService.loadMine();
+      }
       // Only load users if user has permission
       if (this.canViewUsers) {
         this.userDataService.load().pipe(take(1)).subscribe();

--- a/src/app/components/admin/admin-evaluations/admin-evaluations.component.ts
+++ b/src/app/components/admin/admin-evaluations/admin-evaluations.component.ts
@@ -145,7 +145,7 @@ export class AdminEvaluationsComponent implements OnInit, OnDestroy {
       minWidth: '900px',
       data: {
         evaluation: evaluation,
-        scoringModels: this.scoringModels,
+        scoringModels: this.scoringModels.filter(sm => !sm.evaluationId),
         itemStatuses: this.itemStatuses,
         isExisting: !!evaluation.dateCreated,
         canEdit: this.permissionDataService.canEditEvaluation(evaluation.id)


### PR DESCRIPTION
PR: Fix admin evaluation page scoring model filter and data loading                                                                                                                                                 
                                                                                                                                                                                                                      
  Summary                                                                                                                                                                                                             
                                                                                                                                                                                                                      
  - Filter the scoring model dropdown in the Add/Edit Evaluation dialog to only show template scoring models (those not already assigned to an evaluation)                                                            
  - Fix a race condition where refreshing the browser on the admin evaluations page caused the wrong API endpoint (/api/my-evaluations instead of /api/evaluations) to be called
                                                                                                                                                                                                                      
  Changes

  admin-evaluations.component.ts
  - Filter scoring models passed to the evaluation dialog to only include those with a null evaluationId, ensuring only unassigned templates are shown

  admin-container.component.ts
  - Move evaluation data loading from the constructor into the permissionDataService.load() callback in ngOnInit, so that permissions are loaded before determining which endpoint to call
  - Previously, on a fresh page load/refresh, permissions were not yet fetched when the constructor ran, causing hasPermission(ViewEvaluations) to return false and falling back to loadMine()
