### PR TITLE
Add missing development build configuration for localNPM support

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -77,11 +77,20 @@
                 }
               ]
             },
+            "development": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": {
+                "scripts": true,
+                "styles": true,
+                "vendor": true
+              },
+              "namedChunks": true
+            },
             "localNPM": {
               "tsConfig": "tsconfig.local-npm.json"
             }
-          },
-          "defaultConfiguration": ""
+          }
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
@@ -89,9 +98,13 @@
             "port": 4721,
             "buildTarget": "cite-ui:build"
           },
+          "defaultConfiguration": "development",
           "configurations": {
             "production": {
               "buildTarget": "cite-ui:build:production"
+            },
+            "development": {
+              "buildTarget": "cite-ui:build:development"
             },
             "localNPM": {
               "buildTarget": "cite-ui:build:development,localNPM"


### PR DESCRIPTION
The localNPM serve target references build:development,localNPM but no development build configuration existed, causing build failures.