### PR TITLE
Fix evaluation creation dialog and error handling 

### DIFF
--- a/src/app/components/admin/admin-evaluation-edit-dialog/admin-evaluation-edit-dialog.component.ts
+++ b/src/app/components/admin/admin-evaluation-edit-dialog/admin-evaluation-edit-dialog.component.ts
@@ -96,7 +96,7 @@ export class AdminEvaluationEditDialogComponent implements OnInit, OnDestroy {
     if (!saveChanges) {
       this.editComplete.emit({ saveChanges: false, evaluation: null });
     } else {
-      if (this.errorFree) {
+      if (this.errorFree()) {
         this.editComplete.emit({
           saveChanges: saveChanges,
           evaluation: this.data.evaluation,

--- a/src/app/data/evaluation/evaluation-data.service.ts
+++ b/src/app/data/evaluation/evaluation-data.service.ts
@@ -210,6 +210,9 @@ export class EvaluationDataService {
       .subscribe((s) => {
         this.setAsDates(s);
         this.evaluationStore.add(s);
+      },
+      (error) => {
+        this.evaluationStore.setLoading(false);
       });
   }
 


### PR DESCRIPTION
### Summary                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                     
  - Fix errorFree being referenced as a property instead of called as a method, preventing the validation gate from working on save                                                                                                                                                                                                                  
  - Add error handler to the evaluation creation subscription to reset the store loading state on failure                                                                                                                                                                                                                                            

  ### Details

  admin-evaluation-edit-dialog.component.ts: Changed this.errorFree to this.errorFree() — without the parentheses, the expression always evaluated to truthy (a reference to the function), so the validation check was effectively bypassed, allowing evaluations with errors to be submitted.                                                      
  
  evaluation-data.service.ts: Added an error callback to the subscribe() in the create evaluation flow. Previously, if the API call failed, the Akita store remained in a loading state indefinitely, likely blocking the UI. Now setLoading(false) is called on error so the UI recovers.                                                           
                                                                                                                                                                                                                                                                                              